### PR TITLE
small fixes

### DIFF
--- a/src/components/ExampleBox.tsx
+++ b/src/components/ExampleBox.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { cssObj } from '@fuel-ui/css';
+import { cssObj } from "@fuel-ui/css";
 import {
   Alert,
   Box,
@@ -9,13 +9,12 @@ import {
   Tag,
   Text,
   Tooltip,
-} from '@fuel-ui/react';
-import type { ReactNode } from 'react';
+} from "@fuel-ui/react";
+import type { ReactNode } from "react";
 
-import { capitalize } from '../lib/str';
+import { capitalize } from "../lib/str";
 
-import { Heading } from './Heading';
-
+import { Heading } from "./Heading";
 
 export function ExampleBox({
   children,
@@ -24,9 +23,8 @@ export function ExampleBox({
   children: ReactNode;
   error?: any;
 }) {
-  
   return (
-    <Stack gap="$4" css={{ mt: '$8' }}>
+    <Stack gap="$4" css={{ mt: "$8" }}>
       {/* {errorMsg && (
         <Alert css={styles.alert} status="error">
           <Alert.Description>{capitalize(errorMsg)}</Alert.Description>
@@ -34,7 +32,6 @@ export function ExampleBox({
       )} */}
       <Box css={styles.root}>
         <Heading as="h6">
-          Check it working{' '}
           {/* {notDetected && !error && (
             <Tooltip content={downloadContent} side="left">
               <Tag size="xs" color="amber" variant="ghost" leftIcon="Warning">
@@ -62,31 +59,31 @@ export function ExampleBox({
 
 const styles = {
   root: cssObj({
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '$4',
-    padding: '$4',
-    borderRadius: '$md',
-    border: '1px dashed $gray3',
-    maxWidth: '90vw',
-    overflowWrap: 'break-word',
-    '@xl': {
-      maxWidth: '55vw',
+    display: "flex",
+    flexDirection: "column",
+    gap: "$4",
+    padding: "$4",
+    borderRadius: "$md",
+    border: "1px dashed $gray3",
+    maxWidth: "90vw",
+    overflowWrap: "break-word",
+    "@xl": {
+      maxWidth: "55vw",
     },
     h6: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      margin: '$0',
-      color: '$gray10',
-      gap: '$2',
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      margin: "$0",
+      color: "$gray10",
+      gap: "$2",
 
-      '& .fuel_icon': {
-        color: 'currentColor',
+      "& .fuel_icon": {
+        color: "currentColor",
       },
     },
   }),
   alert: cssObj({
-    maxWidth: '100%',
+    maxWidth: "100%",
   }),
 };


### PR DESCRIPTION
Just a small nit.

We should also make it so when you click on the top level menu items with subdirectories like Reference and How to Use GraphQL, it opens a top-level page. Right now, if you click on the top level items nothing happens, and the navigation only changes when you click a subdirectory. 

We could add a simple explanation at the top level pages. 