### PR TITLE
Removing all beta-2 documentation and adding beta-3 depreciation note

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -17,11 +17,8 @@ You can test out the Fuel GraphQL API playground here:
 Beta-4:
 https://beta-4.fuel.network/playground
 
-Beta-3:
+Beta-3: *(deprecated)*:
 https://beta-3.fuel.network/playground
-
-Beta-2 *(deprecated)*:
-https://node-beta-2.fuel.network/playground
 
 You can learn more about the differences between each network [here](https://fuellabs.github.io/fuel-docs/master/networks/networks.html).
 
@@ -30,8 +27,5 @@ You can learn more about the differences between each network [here](https://fue
 Beta-4:
 https://beta-4.fuel.network/graphql
 
-Beta-3:
+Beta-3: *(deprecated)*:
 https://beta-3.fuel.network/graphql
-
-Beta-2 *(deprecated)*:
-https://node-beta-2.fuel.network/graphql

--- a/docs/reference/objects.mdx
+++ b/docs/reference/objects.mdx
@@ -1029,8 +1029,6 @@ The block height of the data availability layer up to which (inclusive) input me
 
 > The status of the message UTXO.
 
-> `fuelBlockSpend`: <a href="/docs/reference/scalars/#u64">`U64`</a><sup>_(beta-2 only)_</sup>
-
 > The block in which the message is spent.
 
 ## `MessageCoin`


### PR DESCRIPTION
Beta-3 has just been depreciated in favour of beta-4. See the announcement below:

https://forum.fuel.network/t/sunsetting-beta-3-testnet/3145