### PR TITLE
Fix Documentation Formatting for BalanceFilterInput

### DIFF
--- a/docs/reference/objects.mdx
+++ b/docs/reference/objects.mdx
@@ -29,7 +29,7 @@ The filter input type used to filter the `balances` query.
 
 **fields:**
 
-`owner`: [`Address!`(/docs/reference/scalars/#address)
+`owner`: [`Address!`](/docs/reference/scalars/#address)
 
 The owner address of the balances.
 

--- a/docs/reference/unions.mdx
+++ b/docs/reference/unions.mdx
@@ -71,7 +71,7 @@ Indicates a contract was deployed.
 
 The status type of a transaction.
 
-[`SubmitedStatus`](/docs/reference/objects/#submittedstatus): The transaction has been submitted.
+[`SubmittedStatus`](/docs/reference/objects/#submittedstatus): The transaction has been submitted.
 
 [`SuccessStatus`](/docs/reference/objects/#successstatus): The transaction has succeeded.
 


### PR DESCRIPTION
#### Overview
While browsing the GraphQL documentation at [Fuel Network's GraphQL Docs](https://graphql-docs.fuel.network/docs/reference/objects/), I noticed a formatting error in the `BalanceFilterInput` section. The argument `owner` was not correctly formatted. Additionally, a spelling correction was needed in the unions page.

#### Changes in This PR
- Corrected the markdown formatting for the `owner` field in the `BalanceFilterInput` section to properly display the hyperlink. The screenshot attached to this PR shows the issue as it appeared in the live documentation.
- Fixed a typographical error in the `unions.mdx` file, changing `SubmitedStatus` to `SubmittedStatus` to align with the correct term.

#### Screenshot of Issue
![Incorrect Formatting in BalanceFilterInput Section](https://github.com/FuelLabs/fuel-graphql-docs/assets/22820692/42ff12e5-89bf-4833-ae31-22430d4b1585)
