### PR TITLE
Updated the formatting for RPC endpoint and GraphQL playground

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -17,5 +17,5 @@ You can test out the Fuel GraphQL API playground <a hredf = "https://testnet.fue
 
 
 ## RPC Endpoint
-This is the RPC endpoint you can use in your applications to query on chain data  : https://testnet.fuel.network/v1/graphql
+This is the RPC endpoint you can use in your applications to query on chain data  : `https://testnet.fuel.network/v1/graphql`
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -12,7 +12,8 @@ The Fuel GraphQL API allows you to query the Fuel blockchain for a wide range of
 
 The playground is an interactive and graphical IDE that includes a reference for queries, mutations, and types. It also provides query validation and context for the underlying GraphQL schema.
 
-You can test out the Fuel GraphQL API playground here: 
+You can test out the Fuel GraphQL API playground here:
+
 https://testnet.fuel.network/v1/playground
 
 ## RPC Endpoint

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -18,4 +18,8 @@ https://testnet.fuel.network/v1/playground
 
 ## RPC Endpoint
 
-This is the RPC endpoint you can use in your applications to query on chain data  : `https://testnet.fuel.network/v1/graphql`.
+This is the RPC endpoint you can use in your applications to interact with the Fuel blockchain, whether it's retrieving on-chain data or sending transactions: 
+
+`https://testnet.fuel.network/v1/graphql`.
+
+> Note that this is the same endpoint used in the playground above.

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -18,7 +18,7 @@ https://testnet.fuel.network/v1/playground
 
 ## RPC Endpoint
 
-This is the RPC endpoint you can use in your applications to interact with the Fuel blockchain, whether it's retrieving on-chain data or sending transactions: 
+This is the RPC endpoint you can use in your applications to interact with the Fuel blockchain, whether it's retrieving on-chain data or sending transactions:
 
 `https://testnet.fuel.network/v1/graphql`.
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -8,14 +8,14 @@ title: Overview
 
 The Fuel GraphQL API allows you to query the Fuel blockchain for a wide range of on-chain data. It can be used to query transactions, balances, block information, and more. You can also use it to simulate and submit transactions on the Fuel network.
 
-## Playground
+## GraphQL Playground
 
 The playground is an interactive and graphical IDE that includes a reference for queries, mutations, and types. It also provides query validation and context for the underlying GraphQL schema.
 
-You can test out the Fuel GraphQL API playground here:
+You can test out the Fuel GraphQL API playground <a hredf = "https://testnet.fuel.network/v1/playground">here</a>
 
-https://testnet.fuel.network/v1/playground
+
 
 ## RPC Endpoint
+This is the RPC endpoint you can use in your applications to query on chain data  : https://testnet.fuel.network/v1/graphql
 
-https://testnet.fuel.network/v1/graphql

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -12,10 +12,9 @@ The Fuel GraphQL API allows you to query the Fuel blockchain for a wide range of
 
 The playground is an interactive and graphical IDE that includes a reference for queries, mutations, and types. It also provides query validation and context for the underlying GraphQL schema.
 
-You can test out the Fuel GraphQL API playground <a hredf = "https://testnet.fuel.network/v1/playground">here</a>
-
-
+You can test out the Fuel GraphQL API playground here: 
+https://testnet.fuel.network/v1/playground
 
 ## RPC Endpoint
-This is the RPC endpoint you can use in your applications to query on chain data  : `https://testnet.fuel.network/v1/graphql`
 
+This is the RPC endpoint you can use in your applications to query on chain data  : `https://testnet.fuel.network/v1/graphql`.


### PR DESCRIPTION
- Updated the heading for Graph QL Section 
- Added some info under the RPC endpoint section to indicate that this link can be used to query on chain data in the applications.